### PR TITLE
Add translit_kit to Language-aware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ important decisions and useful answers you may be interested in.
 :sparkles: Every [contribution](#contributing) is welcome! Add links through pull
 requests or create an issue to start a discussion.
 
-Follow us on [Twitter](https://twitter.com/RubyNLP)
+Follow us on [Twitter](https://twitter.com/NonWebRuby)
 and please spread the word using the `#RubyNLP` hash tag!
 
 <!-- nodoc -->

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ the underlying language.
   Generate strings that match a given regular expression.
 - [verbal_expressions](https://github.com/ryan-endacott/verbal_expressions) -
   Make difficult regular expressions easy.
+- [translit_kit](https://github.com/AnalyzePlatypus/TranslitKit) - Transliterate Hebrew & Yiddish text into Latin characters  
 
 ## Articles, Posts, Talks, and Presentations
 


### PR DESCRIPTION
- Adds [TranslitKit](https://github.com/AnalyzePlatypus/TranslitKit) to the `Language Aware` section
- Corrects the project Twitter feed link (on [L36](https://github.com/arbox/nlp-with-ruby/edit/master/README.md). Fixes Travis build.)

Boilerplate:
I want to contribute to this list and help the maintainers, so:

- [x] I've accepted the terms of the `CC0` License;
- [x] I've added the topic `rubynlp` to the contributed repository